### PR TITLE
Enable http_only flag for xsrf cookie

### DIFF
--- a/app/Http/Middleware/VerifyCsrfToken.php
+++ b/app/Http/Middleware/VerifyCsrfToken.php
@@ -2,6 +2,8 @@
 
 namespace App\Http\Middleware;
 
+use Carbon\Carbon;
+use Symfony\Component\HttpFoundation\Cookie;
 use Illuminate\Foundation\Http\Middleware\VerifyCsrfToken as Middleware;
 
 class VerifyCsrfToken extends Middleware
@@ -14,4 +16,22 @@ class VerifyCsrfToken extends Middleware
     protected $except = [
         //
     ];
+
+    /**
+     * Add the CSRF token to the response cookies with http_only set to true
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Symfony\Component\HttpFoundation\Response  $response
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    protected function addCookieToResponse($request, $response)
+    {
+        $config = config('session');
+        $response->headers->setCookie(
+            new Cookie(
+                'XSRF-TOKEN', $request->session()->token(), Carbon::now()->getTimestamp() + 60 * $config['lifetime'],
+                $config['path'], $config['domain'], $config['secure'], $config['http_only'])
+        );
+        return $response;
+    }
 }


### PR DESCRIPTION
Change proposed due to following report from OWASP ZAP:

```
{u'alert': u'Cookie No HttpOnly Flag',
  u'attack': u'',
  u'confidence': u'Medium',
  u'cweid': u'16',
  u'description': u'A cookie has been set without the HttpOnly flag, which means that the cookie can be accessed by JavaScript. If a malicious script can be run on this page then the cookie will be accessible and can be transmitted to another site. If this is a session cookie then session hijacking may be possible.',
  u'evidence': u'Set-Cookie: XSRF-TOKEN',
  u'id': u'0',
  u'messageId': u'1',
  u'method': u'GET',
  u'name': u'Cookie No HttpOnly Flag',
  u'other': u'',
  u'param': u'XSRF-TOKEN',
  u'pluginId': u'10010',
  u'reference': u'http://www.owasp.org/index.php/HttpOnly',
  u'risk': u'Low',
  u'solution': u'Ensure that the HttpOnly flag is set for all cookies.',
  u'sourceid': u'3',
  u'url': u'http://127.0.0.1:8000/',
  u'wascid': u'13'},
 {u'alert': u'Cookie No HttpOnly Flag',
  u'attack': u'',
  u'confidence': u'Medium',
  u'cweid': u'16',
  u'description': u'A cookie has been set without the HttpOnly flag, which means that the cookie can be accessed by JavaScript. If a malicious script can be run on this page then the cookie will be accessible and can be transmitted to another site. If this is a session cookie then session hijacking may be possible.',
  u'evidence': u'Set-Cookie: XSRF-TOKEN',
  u'id': u'1',
  u'messageId': u'2',
  u'method': u'GET',
  u'name': u'Cookie No HttpOnly Flag',
  u'other': u'',
  u'param': u'XSRF-TOKEN',
  u'pluginId': u'10010',
  u'reference': u'http://www.owasp.org/index.php/HttpOnly',
  u'risk': u'Low',
  u'solution': u'Ensure that the HttpOnly flag is set for all cookies.',
  u'sourceid': u'3',
  u'url': u'http://127.0.0.1:8000/login',
  u'wascid': u'13'}
```